### PR TITLE
Raise Error when the start code is not Null

### DIFF
--- a/sacn/messages/data_packet.py
+++ b/sacn/messages/data_packet.py
@@ -136,7 +136,9 @@ class DataPacket(RootLayer):
            tuple(raw_data[40:44]) != tuple(VECTOR_E131_DATA_PACKET) or \
            raw_data[117] != VECTOR_DMP_SET_PROPERTY:  # REMEMBER: when slicing: [inclusive:exclusive]
             raise TypeError('Some of the vectors in the given raw data are not compatible to the E131 Standard!')
-
+        if raw_data[125] != 0x00:
+            raise TypeError('Not a default Null Start Code for Dimmers per DMX512 & DMX512/1990')
+            
         tmpPacket = DataPacket(cid=raw_data[22:38], sourceName=str(raw_data[44:108]),
                                universe=(0xFF * raw_data[113]) + raw_data[114])  # high byte first
         tmpPacket.priority = raw_data[108]


### PR DESCRIPTION
When the start code is not Null, the packet will probably not be DMX-A data. A full list of start codes can be found here: https://tsp.esta.org/tsp/working_groups/CP/DMXAlternateCodes.php