### PR TITLE
Manual flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ sender[2].dmx_data = (5, 6, 7, 8)  # by the time we are here, the above data wou
 # so instead we are flushing manual
 sender.flush()
 sender.manual_flush = False # keep maunal flush off as long as possible, because if it is on, the automatic 
-# sending of packets is turned off and that would not be legal to the E1.31
+# sending of packets is turned off and that is not recommended
 ```
 
 ### Receiving

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sender = sacn.sACNsender()
 sender.start()
 sender.activate_output(1)
 sender.activate_output(2)
-sender[1].multicast = True
+sender[1].multicast = True # keep in mind that multicast on windows is a bit different
 sender[2].multicast = True
 
 sender.manual_flush = True # turning off the automatic sending of packets

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ receiver implemented this feature of the sACN protocol.
 Example for the usage of the manual_flush:
 ```python
 import sacn
+import time
 
 sender = sacn.sACNsender()
 sender.start()
@@ -122,12 +123,14 @@ sender[2].multicast = True
 
 sender.manual_flush = True # turning off the automatic sending of packets
 sender[1].dmx_data = (1, 2, 3, 4)  # some test DMX data
-sender[2].dmx_data = (5, 6, 7, 8)  # by the time we are here, the above data would be already send out, 
+sender[2].dmx_data = (5, 6, 7, 8)  # by the time we are here, the above data would be already send out,
 # if manual_flush would be False. This could cause some jitter
 # so instead we are flushing manual
+time.sleep(1) # let the sender initalize itself
 sender.flush()
-sender.manual_flush = False # keep maunal flush off as long as possible, because if it is on, the automatic 
+sender.manual_flush = False # keep maunal flush off as long as possible, because if it is on, the automatic
 # sending of packets is turned off and that is not recommended
+sender.stop() # stop sending out
 ```
 
 ### Receiving

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # sACN / E1.31 module
-**BETA!**
 
 This module is a simple sACN library that support the standard DMX message of the protocol.
 It is based on the [2016][e1.31] version of the official ANSI E1.31 standard.
@@ -41,6 +40,7 @@ This feature also uses the sync feature of the sACN protocol (see page 36 on [E1
 Currently this is not implemented like the recommended way (this does not wait before sending out the sync packet), but
 it should work on a normal local network without too many latency differences.
 When the `flush()` function is called, all data is send out at the same time and immediately a sync packet is send out.
+
 ### Receiving
 A very simple solution, as you just create a `sACNreceiver` object and use `start()` a new thread that is running in
 the background and calls the callbacks when new sACN data arrives.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ For full blown DMX support use [OLA](http://opendmx.net/index.php/Open_Lighting_
 
 Currently missing features:
  * discovery messages (receiving)
- * E1.31 sync feature
+ * E1.31 sync feature (on the receiver side)
  * custom ports (because this is not recommended)
  
 Features:
  * out-of-order packet detection like the [E1.31][e1.31] 6.7.2
  * multicast (on Windows this is a bit tricky though)
  * auto flow control (see [The Internals/Sending](#sending))
+ * E1.31 sync feature (see manual_flush)
 
 ## Setup
 This Package is in the pypi. To install the package use `pip install sacn`. Python 3.6 or newer required!
@@ -36,6 +37,10 @@ You can tweak this *fps* by simply change it when creating the `sACNsender` obje
 This function works according to the [E1.31][e1.31]. See 6.6.1 for more information.
 
 Note: Since Version 1.4 there is a manual flush feature available. See Usage/Sending for more info.
+This feature also uses the sync feature of the sACN protocol (see page 36 on [E1.31][e1.31]).
+Currently this is not implemented like the recommended way (this does not wait before sending out the sync packet), but
+it should work on a normal local network without too many latency differences.
+When the `flush()` function is called, all data is send out at the same time and immediately a sync packet is send out.
 ### Receiving
 A very simple solution, as you just create a `sACNreceiver` object and use `start()` a new thread that is running in
 the background and calls the callbacks when new sACN data arrives.
@@ -97,8 +102,12 @@ Note that a bind address is needed on Windows for sending out multicast packets.
  * `fps: int` the frames per second. See explanation above. Has to be >0. Default: 30
  * `universeDiscovery: bool` if true, universe discovery messages are send out via broadcast every 10s. For this 
  feature to function properly on Windows, you have to provide a bind address. Default: True
- * `manual_flush: bool` if set to true, the output-thread will not automatically send out packets. USe the function
+ * `manual_flush: bool` if set to true, the output-thread will not automatically send out packets. Use the function
   `flush()` to send out all universes. Default: False
+  
+When manually flushed, the E1.31 sync feature is used. So all universe data is send out, and after all data was send out
+a sync packet is send to all receivers and then they are allowed to display the received data. Note that not all 
+receiver implemented this feature of the sACN protocol.
   
 Example for the usage of the manual_flush:
 ```python

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ sender[2].dmx_data = (5, 6, 7, 8)  # by the time we are here, the above data wou
 # if manual_flush would be False. This could cause some jitter
 # so instead we are flushing manual
 sender.flush()
-sender.manual_flush = False # keep maunal flush off as long as possible, because if it is on, the automatic sending of 
-# packets is turned off and that would not be legal to the E1.31
+sender.manual_flush = False # keep maunal flush off as long as possible, because if it is on, the automatic 
+# sending of packets is turned off and that would not be legal to the E1.31
 ```
 
 ### Receiving

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ You can create a new `sACNsender` object and provide the necessary information. 
 This creates a new thread that is responsible for sending out the data. Do not forget to `stop()` the thread when 
 finished! If the data is not changed, the same DMX data is send out every second.
 
-The thread sends out the data every *1/fps* seconds. This provides synchronization (the data for all universes is send
-out the same time) and reduces network traffic even if you give the sender new data more often than the *fps*.
+The thread sends out the data every *1/fps* seconds. This reduces network traffic even if you give the sender new data 
+more often than the *fps*.
 A simple description would be to say that the data that you give the sACNsender is subsampled by the *fps*.
 You can tweak this *fps* by simply change it when creating the `sACNsender` object.
 
@@ -71,8 +71,8 @@ Available Attributes for `sender[<universe>].<attribute>` are:
  * `multicast: bool`: set whether to send out via multicast or not. Default: False
  If True the data is send out via multicast and not unicast.
  * `ttl: int`: the time-to-live for the packets that are send out via mutlicast on this universe. Default: 8
- * `priority: int`: the priority for this universe that is send out. If multiple sources in a network are sending to
- the same receiver the data with the highest priority wins. Default: 100
+ * `priority: int`: (must be between 0-200) the priority for this universe that is send out. If multiple sources in a 
+ network are sending to the same receiver the data with the highest priority wins. Default: 100
  * `preview_data: bool`: Flag to mark the data as preview data for visualization purposes. Default: False
  * `dmx_data: tuple`: the DMX data as a tuple. Max length is 512 and for legacy devices all data that is smaller than
  512 is merged to a 512 length tuple with 0 as filler value. The values in the tuple have to be [0-255]!

--- a/sacn/messages/data_packet.py
+++ b/sacn/messages/data_packet.py
@@ -14,12 +14,13 @@ from sacn.messages.root_layer import VECTOR_DMP_SET_PROPERTY, \
 
 class DataPacket(RootLayer):
     def __init__(self, cid: tuple, sourceName: str, universe: int, dmxData: tuple = (), priority: int = 100,
-                 sequence: int = 0, streamTerminated: bool = False, previewData: bool = False, forceSync: bool = False):
+                 sequence: int = 0, streamTerminated: bool = False, previewData: bool = False,
+                 forceSync: bool = False, sync_universe: int = 0):
         self._vector1 = VECTOR_E131_DATA_PACKET
         self._vector2 = VECTOR_DMP_SET_PROPERTY
         self.sourceName: str = sourceName
         self.priority = priority
-        self._syncAddr = (0, 0)  # currently not supported
+        self.syncAddr = sync_universe
         self.universe = universe
         self.option_StreamTerminated: bool = streamTerminated
         self.option_PreviewData: bool = previewData
@@ -49,6 +50,15 @@ class DataPacket(RootLayer):
         if universe not in range(1, 64000):
             raise TypeError(f'universe must be [1-63999]! value was {universe}')
         self._universe = universe
+
+    @property
+    def syncAddr(self) -> int:
+        return self._syncAddr
+    @syncAddr.setter
+    def syncAddr(self, sync_universe: int):
+        if sync_universe not in range(1, 64000):
+            raise TypeError(f'sync_universe must be [1-63999]! value was {sync_universe}')
+        self._syncAddr = sync_universe
 
     @property
     def sequence(self) -> int:
@@ -93,7 +103,7 @@ class DataPacket(RootLayer):
         # priority------------------------------
         rtrnList.append(self._priority)
         # syncAddress---------------------------
-        rtrnList.extend(self._syncAddr)
+        rtrnList.extend(int_to_bytes(self._syncAddr))
         # sequence------------------------------
         rtrnList.append(self._sequence)
         # Options Flags:------------------------
@@ -127,7 +137,7 @@ class DataPacket(RootLayer):
     def make_data_packet(raw_data) -> 'DataPacket':
         """
         Converts raw byte data to a sACN DataPacket. Note that the raw bytes have to come from a 2016 sACN Message.
-        This does not support Sync Addresses, Force_Sync option and DMX Start code!
+        This does not support DMX Start code!
         :param raw_data: raw bytes as tuple or list
         :return: a DataPacket with the properties set like the raw bytes
         """
@@ -143,7 +153,7 @@ class DataPacket(RootLayer):
         tmpPacket = DataPacket(cid=raw_data[22:38], sourceName=str(raw_data[44:108]),
                                universe=(0xFF * raw_data[113]) + raw_data[114])  # high byte first
         tmpPacket.priority = raw_data[108]
-        # SyncAddress in the future?!
+        tmpPacket.syncAddr = (0xFF * raw_data[109]) + raw_data[110]  # high byte first
         tmpPacket.sequence = raw_data[111]
         tmpPacket.option_PreviewData = bool(raw_data[112] & 0b10000000)  # use the 7th bit as preview_data
         tmpPacket.option_StreamTerminated = bool(raw_data[112] & 0b01000000)  # use bit 6 as stream terminated

--- a/sacn/messages/data_packet.py
+++ b/sacn/messages/data_packet.py
@@ -56,7 +56,7 @@ class DataPacket(RootLayer):
         return self._syncAddr
     @syncAddr.setter
     def syncAddr(self, sync_universe: int):
-        if sync_universe not in range(1, 64000):
+        if sync_universe not in range(0, 64000):
             raise TypeError(f'sync_universe must be [1-63999]! value was {sync_universe}')
         self._syncAddr = sync_universe
 

--- a/sacn/messages/data_packet.py
+++ b/sacn/messages/data_packet.py
@@ -14,7 +14,7 @@ from sacn.messages.root_layer import VECTOR_DMP_SET_PROPERTY, \
 
 class DataPacket(RootLayer):
     def __init__(self, cid: tuple, sourceName: str, universe: int, dmxData: tuple = (), priority: int = 100,
-                 sequence: int = 0, streamTerminated: bool = False, previewData: bool = False):
+                 sequence: int = 0, streamTerminated: bool = False, previewData: bool = False, forceSync: bool = False):
         self._vector1 = VECTOR_E131_DATA_PACKET
         self._vector2 = VECTOR_DMP_SET_PROPERTY
         self.sourceName: str = sourceName
@@ -23,6 +23,7 @@ class DataPacket(RootLayer):
         self.universe = universe
         self.option_StreamTerminated: bool = streamTerminated
         self.option_PreviewData: bool = previewData
+        self.option_ForceSync: bool = forceSync
         self.sequence = sequence
         self.dmxData = dmxData
         super().__init__(126 + len(dmxData), cid, VECTOR_ROOT_E131_DATA)
@@ -101,6 +102,8 @@ class DataPacket(RootLayer):
         tmpOptionsFlags += int(self.option_StreamTerminated) << 6
         # preview data:
         tmpOptionsFlags += int(self.option_PreviewData) << 7
+        # force synchronization
+        tmpOptionsFlags += int(self.option_ForceSync) << 5
         rtrnList.append(tmpOptionsFlags)
         # universe:-----------------------------
         rtrnList.extend(int_to_bytes(self._universe))
@@ -143,7 +146,8 @@ class DataPacket(RootLayer):
         # SyncAddress in the future?!
         tmpPacket.sequence = raw_data[111]
         tmpPacket.option_PreviewData = bool(raw_data[112] & 0b10000000)  # use the 7th bit as preview_data
-        tmpPacket.option_StreamTerminated = bool(raw_data[112] & 0b01000000)
+        tmpPacket.option_StreamTerminated = bool(raw_data[112] & 0b01000000)  # use bit 6 as stream terminated
+        tmpPacket.option_ForceSync = bool(raw_data[112] & 0b00100000)  # use bit 5 as force sync
         tmpPacket.dmxData = raw_data[126:638]
         return tmpPacket
 

--- a/sacn/messages/sync_packet.py
+++ b/sacn/messages/sync_packet.py
@@ -1,0 +1,67 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+"""
+This implements the sync packet from the E1.31 standard.
+Information about sACN: http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf
+"""
+from sacn.messages.root_layer import VECTOR_ROOT_E131_EXTENDED, \
+    VECTOR_E131_EXTENDED_SYNCHRONIZATION, \
+    RootLayer, \
+    int_to_bytes, \
+    make_flagsandlength
+
+class SyncPacket(RootLayer):
+    def __init__(self, cid: tuple, syncAddr: int, sequence: int = 0):
+        self.syncAddr = syncAddr
+        self.sequence = sequence
+        super().__init__(49, cid, VECTOR_ROOT_E131_EXTENDED)
+
+    @property
+    def syncAddr(self) -> int:
+        return self._syncAddr
+    @syncAddr.setter
+    def syncAddr(self, sync_universe: int):
+        if sync_universe not in range(1, 64000):
+            raise TypeError(f'sync_universe must be [1-63999]! value was {sync_universe}')
+        self._syncAddr = sync_universe
+
+    @property
+    def sequence(self) -> int:
+        return self._sequence
+    @sequence.setter
+    def sequence(self, sequence: int):
+        if sequence not in range(0, 256):
+            raise TypeError(f'Sequence is a byte! values: [0-255]! value was {sequence}')
+        self._sequence = sequence
+    def sequence_increase(self):
+        self._sequence += 1
+        if self._sequence > 0xFF:
+            self._sequence = 0
+
+    def getBytes(self) -> tuple:
+        rtrnList = super().getBytes()
+        rtrnList.extend(make_flagsandlength(self.length - 38))
+        rtrnList.extend(VECTOR_E131_EXTENDED_SYNCHRONIZATION)
+        rtrnList.append(self._sequence)
+        rtrnList.extend(int_to_bytes(self._syncAddr))
+        rtrnList.extend((0, 0))  # the empty reserved slots
+        return rtrnList
+
+    @staticmethod
+    def make_sync_packet(raw_data) -> 'SyncPacket':
+        """
+        Converts raw byte data to a sACN SyncPacket. Note that the raw bytes have to come from a 2016 sACN Message.
+        :param raw_data: raw bytes as tuple or list
+        :return: a SyncPacket with the properties set like the raw bytes
+        """
+        # Check if the length is sufficient
+        if len(raw_data) < 47:
+            raise TypeError('The length of the provided data is not long enough! Min length is 47!')
+        # Check if the three Vectors are correct
+        if tuple(raw_data[18:22]) != tuple(VECTOR_ROOT_E131_EXTENDED) or \
+           tuple(raw_data[40:44]) != tuple(VECTOR_E131_EXTENDED_SYNCHRONIZATION):
+            # REMEMBER: when slicing: [inclusive:exclusive]
+            raise TypeError('Some of the vectors in the given raw data are not compatible to the E131 Standard!')
+        tmpPacket = SyncPacket(cid=raw_data[22:38], syncAddr=(0xFF * raw_data[45]) + raw_data[46])
+        tmpPacket.sequence = raw_data[44]
+        return tmpPacket

--- a/sacn/sender.py
+++ b/sacn/sender.py
@@ -54,9 +54,9 @@ class sACNsender:
             pass
 
     @property
-    def maunal_flush(self) -> bool:
+    def manual_flush(self) -> bool:
         return self._output_thread.manual_flush
-    @maunal_flush.setter
+    @manual_flush.setter
     def manual_flush(self, manual_flush: bool) -> None:
         self._output_thread.manual_flush = manual_flush
 

--- a/sacn/sender.py
+++ b/sacn/sender.py
@@ -53,6 +53,16 @@ class sACNsender:
         except:
             pass
 
+    @property
+    def maunal_flush(self) -> bool:
+        return self._output_thread.manual_flush
+    @maunal_flush.setter
+    def manual_flush(self, manual_flush: bool) -> None:
+        self._output_thread.manual_flush = manual_flush
+
+    def flush(self):
+        self._output_thread.send_out_all_universes()
+
     def activate_output(self, universe: int) -> None:
         """
         Activates a universe that's then starting to sending every second.

--- a/sacn/sending/output.py
+++ b/sacn/sending/output.py
@@ -38,13 +38,3 @@ class Output:
     def preview_data(self, preview_data: bool):
         self._packet.option_PreviewData = preview_data
 
-#
-# class customList(list):
-#     def __init__(self, args):
-#         super().__init__(args)
-#         self.callbacks: list = []
-#
-#     def __setitem__(self, key, value):
-#         super().__setitem__(key, value)
-#         for callback in self.callbacks:
-#             callback()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='sacn',
-      version='1.3',
+      version='1.4',
       description='sACN / E1.31 module for easy handling of DMX data over ethernet',
       url='https://www.github.com/Hundemeier/sacn',
       author='Hundemeier',


### PR DESCRIPTION
To send out multiple data packets at the same time for less jitter/flickering on the receiver, a manual flush feature was implemented as proposed by @ahodges9 in issue #7.