### PR TITLE
Log network errors instead of crashing silently, fix logging configuration

### DIFF
--- a/sacn/__init__.py
+++ b/sacn/__init__.py
@@ -4,4 +4,4 @@ from sacn.messages.data_packet import DataPacket
 from sacn.messages.universe_discovery import UniverseDiscoveryPacket
 
 import logging
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+logging.getLogger('sacn').addHandler(logging.NullHandler())

--- a/sacn/receiving/receiver_thread.py
+++ b/sacn/receiving/receiver_thread.py
@@ -30,10 +30,11 @@ class receiverThread(threading.Thread):
         self.lastDataTimestamps: dict = {}
         # store the last sequence number of a universe here:
         self.lastSequence: dict = {}
+        self.logger = logging.getLogger('sacn')
         super().__init__(name='sACN input/receiver thread')
 
     def run(self):
-        logging.info(f'Started new sACN receiver thread')
+        self.logger.info(f'Started new sACN receiver thread')
         self.socket.settimeout(0.1)  # timeout as 100ms
         self.enabled_flag = True
         while self.enabled_flag:
@@ -49,7 +50,7 @@ class receiverThread(threading.Thread):
                 tmp_packet = DataPacket.make_data_packet(raw_data)
             except:  # try to make a DataPacket. If it fails just go over it
                 continue
-            logging.debug(f'Received sACN packet:\n{tmp_packet}')
+            self.logger.debug(f'Received sACN packet:\n{tmp_packet}')
 
             self.check_for_stream_terminated_and_refresh_timestamp(tmp_packet)
             self.refresh_priorities(tmp_packet)
@@ -58,7 +59,7 @@ class receiverThread(threading.Thread):
             if not self.is_legal_sequence(tmp_packet):  # check for bad sequence number
                 continue
             self.fire_callbacks_universe(tmp_packet)
-        logging.info('Stopped sACN receiver thread')
+        self.logger.info('Stopped sACN receiver thread')
 
     def check_for_timeouts(self) -> None:
         # check all DataTimestamps for timeouts
@@ -145,7 +146,7 @@ class receiverThread(threading.Thread):
         if packet.universe not in self.previousData.keys() or \
            self.previousData[packet.universe] is None or \
            self.previousData[packet.universe] != packet.dmxData:
-            logging.debug('')
+            self.logger.debug('')
             # set previous data and inherit callbacks
             self.previousData[packet.universe] = packet.dmxData
             for callback in self.callbacks[packet.universe]:

--- a/sacn/sending/output_thread.py
+++ b/sacn/sending/output_thread.py
@@ -29,9 +29,10 @@ class OutputThread(threading.Thread):
         self._socket: socket.socket = None
         self.universeDiscovery: bool = universe_discovery
         self.manual_flush: bool = False
+        self.logger = logging.getLogger('sacn')
 
     def run(self):
-        logging.info('Started sACN sender thread.')
+        self.logger.info('Started sACN sender thread.')
         self._socket = socket.socket(socket.AF_INET,  # Internet
                                      socket.SOCK_DGRAM)  # UDP
         try:
@@ -41,9 +42,9 @@ class OutputThread(threading.Thread):
 
         try:
             self._socket.bind((self._bindAddress, self._bind_port))
-            logging.info(f'Bind sender thread to IP:{self._bindAddress} Port:{self._bind_port}')
+            self.logger.info(f'Bind sender thread to IP:{self._bindAddress} Port:{self._bind_port}')
         except:
-            logging.exception(f'Could not bind to IP:{self._bindAddress} Port:{self._bind_port}')
+            self.logger.exception(f'Could not bind to IP:{self._bindAddress} Port:{self._bind_port}')
 
         last_time_uni_discover = 0
         self.enabled_flag = True
@@ -70,7 +71,7 @@ class OutputThread(threading.Thread):
             time.sleep(time_to_sleep)
             # this sleeps nearly exactly so long that the loop is called every 1/fps seconds
         self._socket.close()
-        logging.info('Stopped sACN sender thread')
+        self.logger.info('Stopped sACN sender thread')
 
     def send_out(self, output: Output):
         # 1st: Destination (check if multicast)
@@ -99,9 +100,9 @@ class OutputThread(threading.Thread):
         MESSAGE = bytearray(packet.getBytes())
         try:
             self._socket.sendto(MESSAGE, (destination, DEFAULT_PORT))
-            logging.debug(f'Send out Packet to {destination}:{DEFAULT_PORT} with following content:\n{packet}')
+            self.logger.debug(f'Send out Packet to {destination}:{DEFAULT_PORT} with following content:\n{packet}')
         except OSError as e:
-            logging.warning('Failed to send packet', exc_info=e)
+            self.logger.warning('Failed to send packet', exc_info=e)
 
     def send_out_all_universes(self):
         """

--- a/sacn/sending/output_thread.py
+++ b/sacn/sending/output_thread.py
@@ -97,8 +97,11 @@ class OutputThread(threading.Thread):
 
     def send_packet(self, packet, destination: str):
         MESSAGE = bytearray(packet.getBytes())
-        self._socket.sendto(MESSAGE, (destination, DEFAULT_PORT))
-        logging.debug(f'Send out Packet to {destination}:{DEFAULT_PORT} with following content:\n{packet}')
+        try:
+            self._socket.sendto(MESSAGE, (destination, DEFAULT_PORT))
+            logging.debug(f'Send out Packet to {destination}:{DEFAULT_PORT} with following content:\n{packet}')
+        except OSError as e:
+            logging.warning('Failed to send packet', exc_info=e)
 
     def send_out_all_universes(self):
         """


### PR DESCRIPTION
Not sure what the ideal behaviour is when there's a socket error in the output thread; in master the thread dies with no way to recover, this PR makes it log and continue.

I've also updated the logging statements to use the namespace set up in __init__ instead of the root logger.