### PR TITLE
Allow flushing a custom subset of universes

### DIFF
--- a/sacn/sending/output_thread.py
+++ b/sacn/sending/output_thread.py
@@ -105,7 +105,7 @@ class OutputThread(threading.Thread):
         except OSError as e:
             self.logger.warning('Failed to send packet', exc_info=e)
 
-    def send_out_all_universes(self, sync_universe: int):
+    def send_out_all_universes(self, sync_universe: int, universes: dict):
         """
         Sends out all universes in one go. This is not done by this thread! This is done by the caller's thread.
         This uses the E1.31 sync mechanism to try to sync all universes.
@@ -113,7 +113,7 @@ class OutputThread(threading.Thread):
         """
         # go through the list of outputs and send everything out
         # Note: dict may changes size during iteration (multithreading)
-        for output in list(self._outputs.values()):
+        for output in list(universes.values()):
             output._packet.syncAddr = sync_universe  # temporarily set the sync universe
             self.send_out(output)
             output._packet.syncAddr = 0


### PR DESCRIPTION
This adds the ability to send a subset of the activated universes when calling `sACNsender.flush`, if not provided it will send all active universes like it did before.