### PR TITLE
data and uni discovery source name utf8 fixups

### DIFF
--- a/sacn/messages/data_packet.py
+++ b/sacn/messages/data_packet.py
@@ -37,6 +37,17 @@ class DataPacket(RootLayer):
                f'CID: {self._cid}'
 
     @property
+    def sourceName(self) -> str:
+        return self._sourceName
+
+    @sourceName.setter
+    def sourceName(self, sourceName: int):
+        tmp_sourceName_length = len(str(sourceName).encode('UTF-8'))
+        if tmp_sourceName_length > 63:
+            raise ValueError(f'sourceName must be less than 64 bytes when UTF-8 encoded! "{sourceName}" is {tmp_sourceName_length} bytes')
+        self._sourceName = sourceName
+
+    @property
     def priority(self) -> int:
         return self._priority
 
@@ -122,11 +133,11 @@ class DataPacket(RootLayer):
         # Vector Framing Layer:-----------------
         rtrnList.extend(VECTOR_E131_DATA_PACKET)
         # sourceName:---------------------------
-        # make a 64 byte long sourceName
-        tmpSourceName = [0] * 64
-        for i in range(0, min(len(tmpSourceName), len(self.sourceName))):
-            tmpSourceName[i] = ord(self.sourceName[i])
+        # UTF-8 encode the string
+        tmpSourceName = str(self._sourceName).encode('UTF-8')
         rtrnList.extend(tmpSourceName)
+        # pad to 64 bytes
+        rtrnList.extend([0] * (64 - len(tmpSourceName)))
         # priority------------------------------
         rtrnList.append(self._priority)
         # syncAddress---------------------------

--- a/sacn/messages/data_packet_test.py
+++ b/sacn/messages/data_packet_test.py
@@ -171,6 +171,18 @@ def test_str():
     assert packet.__str__() == "sACN DataPacket: Universe: 62000, Priority: 195, Sequence: 34, CID: (16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7, 9, 8)"
 
 
+def test_sourceName():
+    # test string has 25 characters but is 64 bytes (1 too many) when UTF-8 encoded
+    overlength_string = "𔑑覱֪I𤵎⠣Ķ'𫳪爓Û:𢏴㓑ò4𰬀鿹џ>𖬲膬ЩJ𞄇"
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    with pytest.raises(ValueError):
+        packet.sourceName = overlength_string
+    # test constructor
+    with pytest.raises(ValueError):
+        packet = DataPacket(cid=tuple(range(0, 16)), sourceName=overlength_string, universe=1)
+
+
 def test_priority():
     packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
     # test property setter

--- a/sacn/messages/universe_discovery.py
+++ b/sacn/messages/universe_discovery.py
@@ -22,6 +22,17 @@ class UniverseDiscoveryPacket(RootLayer):
         super().__init__((len(universes) * 2) + 120, cid, VECTOR_ROOT_E131_EXTENDED)
 
     @property
+    def sourceName(self) -> str:
+        return self._sourceName
+
+    @sourceName.setter
+    def sourceName(self, sourceName: int):
+        tmp_sourceName_length = len(str(sourceName).encode('UTF-8'))
+        if tmp_sourceName_length > 63:
+            raise ValueError(f'sourceName must be less than 64 bytes when UTF-8 encoded! "{sourceName}" is {tmp_sourceName_length} bytes')
+        self._sourceName = sourceName
+
+    @property
     def page(self) -> int:
         return self._page
 
@@ -62,11 +73,12 @@ class UniverseDiscoveryPacket(RootLayer):
         # Vector Framing Layer:------------------------------
         rtrnList.extend(VECTOR_E131_EXTENDED_DISCOVERY)
         # source Name Framing Layer:-------------------------
-        # make a 64 byte long sourceName
-        tmpSourceName = [0] * 64
-        for i in range(0, min(len(tmpSourceName), len(self.sourceName))):
-            tmpSourceName[i] = ord(self.sourceName[i])
+        # sourceName:---------------------------
+        # UTF-8 encode the string
+        tmpSourceName = str(self._sourceName).encode('UTF-8')
         rtrnList.extend(tmpSourceName)
+        # pad to 64 bytes
+        rtrnList.extend([0] * (64 - len(tmpSourceName)))
         # reserved fields:-----------------------------------
         rtrnList.extend([0] * 4)
         # Universe Discovery Layer:-------------------------------------

--- a/sacn/messages/universe_discovery_test.py
+++ b/sacn/messages/universe_discovery_test.py
@@ -24,6 +24,18 @@ def test_constructor():
         UniverseDiscoveryPacket(tuple(range(0, 17)), sourceName, universes)
 
 
+def test_sourceName():
+    # test string has 25 characters but is 64 bytes (1 too many) when UTF-8 encoded
+    overlength_string = "𔑑覱֪I𤵎⠣Ķ'𫳪爓Û:𢏴㓑ò4𰬀鿹џ>𖬲膬ЩJ𞄇"
+    packet = UniverseDiscoveryPacket(tuple(range(0, 16)), "Test", ())
+    # test property setter
+    with pytest.raises(ValueError):
+        packet.sourceName = overlength_string
+    # test constructor
+    with pytest.raises(ValueError):
+        packet = UniverseDiscoveryPacket(tuple(range(0, 16)), overlength_string, ())
+
+
 def test_page():
     packet = UniverseDiscoveryPacket(tuple(range(0, 16)), "Test", ())
     # test property setter


### PR DESCRIPTION
sourceName was silently truncated, based on character, not byte, count
now a property with an encoded length-checking setter
added test coverage