### PR TITLE
added remove_listener function as described in #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Functions:
    The callback should have one argument: `callback(packet)`
      * `packet: DataPacket`: the received DataPacket with all information
  * `remove_listener(<callback>)`: removes a previously registered listener regardless of the trigger.
+ This means a listener can only be removed completely, even if it was listening to multiple universes.
  If the function never was registered, nothing happens. Note: if a function was registered multiple times, this remove function needs to be called only once.
 
 ### DataPacket

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Functions:
    You can also use the decorator `@listen_on('universe', universe=<universe>)`.
    The callback should have one argument: `callback(packet)`
      * `packet: DataPacket`: the received DataPacket with all information
+ * `remove_listener(<callback>)`: removes a previously registered listener regardless of the trigger.
+ If the function never was registered, nothing happens. Note: if a function was registered multiple times, this remove function needs to be called only once.
 
 ### DataPacket
 This is an abstract representation of an sACN Data packet that carries the DMX data. This class is used internally by

--- a/sacn/receiver.py
+++ b/sacn/receiver.py
@@ -77,6 +77,20 @@ class sACNreceiver(ReceiverHandlerListener):
         else:
             raise TypeError(f'The given trigger "{trigger}" is not a valid one!')
 
+    def remove_listener(self, func: callable) -> None:
+        """
+        Removes the given function from all listening options (see LISTEN_ON_OPTIONS).
+        If the function never was registered, nothing happens. Note: if a function was registered multiple times,
+        this remove function needs to be called only once.
+        :param func: the callback
+        """
+        for _trigger, listeners in self._callbacks.items():
+            while True:
+                try:
+                    listeners.remove(func)
+                except ValueError:
+                    break
+
     def join_multicast(self, universe: int) -> None:
         """
         Joins the multicast address that is used for the given universe. Note: If you are on Windows you must have given


### PR DESCRIPTION
Adds a new function to the receiver to remove a listener from the receiver.
The feature request can be found in #34.