### PR TITLE
Close Sockets on Stop

### DIFF
--- a/sacn/receiver.py
+++ b/sacn/receiver.py
@@ -127,7 +127,8 @@ class sACNreceiver(ReceiverHandlerListener):
 
     def stop(self) -> None:
         """
-        Stops a running thread. If no thread was started nothing happens.
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
         """
         self._handler.socket.stop()
 

--- a/sacn/receiving/receiver_socket_udp.py
+++ b/sacn/receiving/receiver_socket_udp.py
@@ -31,12 +31,12 @@ class ReceiverSocketUDP(ReceiverSocketBase):
 
     def start(self):
         # initialize thread infos
-        thread = threading.Thread(
+        self._thread = threading.Thread(
             target=self.receive_loop,
             name=THREAD_NAME
         )
-        # thread.setDaemon(True)  # TODO: might be beneficial to use a daemon thread
-        thread.start()
+        # self._thread.setDaemon(True)  # TODO: might be beneficial to use a daemon thread
+        self._thread.start()
 
     def receive_loop(self) -> None:
         """
@@ -63,6 +63,12 @@ class ReceiverSocketUDP(ReceiverSocketBase):
         Stop a potentially running thread by gracefull shutdown. Does not stop the thread immediately.
         """
         self._enabled_flag = False
+        try:
+            self._thread.join()
+            # stop the socket, after the loop terminated
+            self._socket.close()
+        except AttributeError:
+            pass
 
     def join_multicast(self, multicast_addr: str) -> None:
         """

--- a/sacn/receiving/receiver_socket_udp.py
+++ b/sacn/receiving/receiver_socket_udp.py
@@ -60,7 +60,8 @@ class ReceiverSocketUDP(ReceiverSocketBase):
 
     def stop(self) -> None:
         """
-        Stop a potentially running thread by gracefull shutdown. Does not stop the thread immediately.
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
         """
         self._enabled_flag = False
         try:

--- a/sacn/sender.py
+++ b/sacn/sender.py
@@ -148,7 +148,8 @@ class sACNsender:
 
     def stop(self) -> None:
         """
-        Tries to stop a current running sender. A running Thread will be stopped and should terminate.
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
         """
         self._sender_handler.stop()
 

--- a/sacn/sending/sender_socket_udp.py
+++ b/sacn/sending/sender_socket_udp.py
@@ -63,7 +63,8 @@ class SenderSocketUDP(SenderSocketBase):
 
     def stop(self) -> None:
         """
-        Stop a potentially running thread by gracefull shutdown. Does not stop the thread immediately.
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
         """
         self._enabled_flag = False
         # wait for the thread to finish

--- a/sacn/sending/sender_socket_udp.py
+++ b/sacn/sending/sender_socket_udp.py
@@ -40,12 +40,12 @@ class SenderSocketUDP(SenderSocketBase):
 
     def start(self):
         # initialize thread infos
-        thread = threading.Thread(
+        self._thread = threading.Thread(
             target=self.send_loop,
             name=THREAD_NAME
         )
-        # thread.setDaemon(True)  # TODO: might be beneficial to use a daemon thread
-        thread.start()
+        # self._thread.setDaemon(True)  # TODO: might be beneficial to use a daemon thread
+        self._thread.start()
 
     def send_loop(self) -> None:
         self._logger.info(f'Started {THREAD_NAME}')
@@ -66,6 +66,13 @@ class SenderSocketUDP(SenderSocketBase):
         Stop a potentially running thread by gracefull shutdown. Does not stop the thread immediately.
         """
         self._enabled_flag = False
+        # wait for the thread to finish
+        try:
+            self._thread.join()
+            # stop the socket, after the loop terminated
+            self._socket.close()
+        except AttributeError:
+            pass
 
     def send_unicast(self, data: RootLayer, destination: str) -> None:
         self.send_packet(data.getBytes(), destination)


### PR DESCRIPTION
Close the underlying UDP sockets when a `stop` method is called. Note: after stopping a sender or receiver, no call to start should happen again. Instead construct a new sender or receiver.

Might fix #38 .