### PR TITLE
Make multicast functional on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,14 @@ receiver.start()  # start the receiving thread
 def callback(packet):  # packet type: sacn.DataPacket
     print(packet.dmxData)  # print the received DMX data
 
-# optional: if you want to use multicast use this function with the universe as parameter
+# optional: if multicast is desired, join with the universe number as parameter
 receiver.join_multicast(1)
 
 time.sleep(10)  # receive for 10 seconds
+
+# optional: if multicast was previously joined
+receiver.leave_multicast(1)
+
 receiver.stop()
 ```
 

--- a/example.py
+++ b/example.py
@@ -55,6 +55,9 @@ send_out_for_2s(2)
 
 sender.deactivate_output(2)
 
+receiver.leave_multicast(1)
+receiver.leave_multicast(2)
+
 # stop both threads
 receiver.stop()
 sender.stop()

--- a/sacn/receiving/receiver_socket_udp.py
+++ b/sacn/receiving/receiver_socket_udp.py
@@ -75,7 +75,7 @@ class ReceiverSocketUDP(ReceiverSocketBase):
         """
         Join a specific multicast address by string. Only IPv4.
         """
-        self._socket.setsockopt(socket.SOL_IP, socket.IP_ADD_MEMBERSHIP,
+        self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
                                 socket.inet_aton(multicast_addr) +
                                 socket.inet_aton(self._bind_address))
 
@@ -84,7 +84,7 @@ class ReceiverSocketUDP(ReceiverSocketBase):
         Leave a specific multicast address by string. Only IPv4.
         """
         try:
-            self._socket.setsockopt(socket.SOL_IP, socket.IP_DROP_MEMBERSHIP,
+            self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP,
                                     socket.inet_aton(multicast_addr) +
                                     socket.inet_aton(self._bind_address))
         except socket.error:  # try to leave the multicast group for the universe


### PR DESCRIPTION
Windows uses socket.IPPROTO_IP for group membership functions.  I haven't been able to test on other OSes but it appears likely this should work universally.  Would need other test platforms to confirm.

Also shortened README.md line 151 comment to eliminate flake warnings

And added multicast leaves to the two examples that included joins, just to illustrate good practice.