### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.6'
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,16 +5,33 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 10
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.11"]
+        include:
+        - os: ubuntu-latest
+          python-version: "3.10"
+        - os: ubuntu-latest
+          python-version: "3.9"
+        - os: ubuntu-latest
+          python-version: "3.8"
+        - os: ubuntu-latest
+          python-version: "3.7"
+        - os: "ubuntu-20.04"
+          python-version: "3.6"
+        - os: macos-latest
+          python-version: "3.6"
+        - os: windows-latest
+          python-version: "3.6"
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Update to current Node.js actions
Add python 3.10 and 3.11 versions for ubuntu
Move 3.6 to ubuntu 20.04 for arch complaints

Add windows and macos tests, just bracketing 3.6 and 3.11