### PR TITLE
Update receiver_socket_udp.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ receiver.stop()
 The usage of the receiver is simpler than the sender.
 The `sACNreceiver` can be initialized with the following parameters:
  * `bind_address: str`: Provide an IP-Address to bind to if you want to receive multicast packets from a specific interface.
+ _Note:_ This parameter is ignored on Linux when binding the socket to an address, but is used in subscribing the
+ multicast group to a correct interface. If you have multiple interfaces within your system you will need to
+ specify this parameter to ensure the multicast group join is completed on the correct interface and you receive
+ sACN traffic.
  * `bind_port: int`: Default: 5568. It is not recommended to change this value!
  Only use when you are know what you are doing!
 

--- a/sacn/receiving/receiver_socket_udp.py
+++ b/sacn/receiving/receiver_socket_udp.py
@@ -3,6 +3,7 @@
 import socket
 import threading
 import time
+import platform
 from sacn.receiving.receiver_socket_base import ReceiverSocketBase, ReceiverSocketListener
 
 THREAD_NAME = 'sACN input/receiver thread'
@@ -26,7 +27,11 @@ class ReceiverSocketUDP(ReceiverSocketBase):
             self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         except socket.error:  # Not all systems support multiple sockets on the same port and interface
             pass
-        self._socket.bind((self._bind_address, self._bind_port))
+        os_name = platform.system()
+        if os_name == "Linux":
+            self._socket.bind(("", self._bind_port))
+        else:
+            self._socket.bind((self._bind_address, self._bind_port))
         self._logger.info(f'Bind receiver socket to IP: {self._bind_address} port: {self._bind_port}')
 
     def start(self):


### PR DESCRIPTION
Proposed fix for #47 - allowing for differences between Windows and Linux.

Noting that I'm not clear that the difference between the Linux and Windows implementation is needed; but I don't have the ability to test that; so I've added use of the platform module to behave differently between the two operating systems.